### PR TITLE
fix: remove pull_request.merged condition for release tag creation

### DIFF
--- a/.github/actions/run-opencode/action.yml
+++ b/.github/actions/run-opencode/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Run OpenCode AI
-      uses: anomalyco/opencode/github@006a05abe8dd6ba5532bd93af77f3ca648cab540 # v1.14.33
+      uses: anomalyco/opencode/github@277f1c71486ed4795875d09bb5c0bbe504f06dd5 # v1.14.40
       timeout-minutes: ${{ inputs.timeout-minutes }}
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
   create-release:
     name: Create Release Tag
     runs-on: ubuntu-latest
-    # if: github.actor != 'dependabot[bot]' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.actor != 'dependabot[bot]' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [quality, test]
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,11 +143,15 @@ jobs:
       - name: Commit Version Changes
         if: steps.bump.outputs.skip_release != 'true'
         run: |
+          # Get the branch name dynamically (works for both PR merges and direct pushes)
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          echo "Pushing to branch: $BRANCH_NAME"
+
           # Check if there are changes to commit
           if [ -n "$(git status --porcelain)" ]; then
             git add CHANGELOG.md package.json
             git commit -m "chore: release v${{ steps.bump.outputs.new_version }}"
-            git push origin main
+            git push origin "$BRANCH_NAME"
             echo "📝 Committed and pushed version changes"
           else
             echo "ℹ️ No files to commit"
@@ -161,7 +165,7 @@ jobs:
             echo "🏷️ Tag $TAG already exists, skipping tag creation"
           else
             git tag -a "$TAG" -m "Release $TAG"
-            git push origin "$TAG"
+            git push origin "$TAG" --force-if-needed
             echo "🏷️ Created and pushed tag: $TAG"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
   create-release:
     name: Create Release Tag
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.pull_request.merged == true
+    # if: github.actor != 'dependabot[bot]' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [quality, test]
     permissions:
       contents: write

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/setup-environment
 
       - name: Run Fallow analysis
-        uses: fallow-rs/fallow@509b5fed07eccbdaf95e83700cd0d06b97b6abe5 # v2.63.0
+        uses: fallow-rs/fallow@4e148af6934d4c077fde98a8e7708d4dfbbb2540 # v2.66.2
         with:
           format: sarif
           comment: true

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run Issue Triage
         if: steps.check.outputs.result == 'true'
-        uses: anomalyco/opencode/github@006a05abe8dd6ba5532bd93af77f3ca648cab540 # v1.14.33
+        uses: anomalyco/opencode/github@277f1c71486ed4795875d09bb5c0bbe504f06dd5 # v1.14.40
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: ./.github/actions/disable-submodules
 
       - name: Run Code Review
-        uses: anomalyco/opencode/github@006a05abe8dd6ba5532bd93af77f3ca648cab540 # v1.14.33
+        uses: anomalyco/opencode/github@277f1c71486ed4795875d09bb5c0bbe504f06dd5 # v1.14.40
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/knowledge/DECISIONS.md
+++ b/knowledge/DECISIONS.md
@@ -931,8 +931,9 @@ git push origin v1.2.3
 1. **CI Workflow (`ci.yml`)**:
    - Added `Commit Version Changes` step after changelogen to commit CHANGELOG.md and package.json
    - Added tag existence check before creating tags (prevents "tag already exists" errors)
-   - Limited `create-release` job to only run on merged PRs (`github.event.pull_request.merged == true`)
    - Removed `Security Scan` and `Docker Security Scan` from main branch push (only run on PRs)
+   - Made release trigger dynamic: uses `GITHUB_HEAD_REF` for PRs or extracts branch from `GITHUB_REF` for direct pushes
+   - Removed `pull_request.merged` condition (was causing release to skip on non-PR main pushes)
 
 2. **Release Workflow (`release.yml`)**:
    - Removed broken `workflow_dispatch` trigger (referenced non-existent bump-version job)
@@ -948,8 +949,8 @@ git push origin v1.2.3
 2. After CI passes → create-release job:
    - Runs changelogen --bump (updates package.json + CHANGELOG.md)
    - Commits changes with "chore: release v<x.y.z>"
-   - Pushes commit to main
-   - Creates and pushes version tag (e.g., v0.1.0)
+   - Pushes commit to branch dynamically
+   - Creates and pushes version tag (e.g., v0.1.0) with --force-if-needed
 3. Tag pushed → release.yml creates GitHub Release
 ```
 


### PR DESCRIPTION
## Summary
- Removes the github.event.pull_request.merged == true condition from CI release job
- The release tag was being skipped because the condition only worked for merged PRs, not direct pushes to main
- Now triggers on any push to main after CI passes