### PR TITLE
fix: run oxfmt before commit in release workflow

### DIFF
--- a/.github/actions/run-opencode/action.yml
+++ b/.github/actions/run-opencode/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Run OpenCode AI
-      uses: anomalyco/opencode/github@277f1c71486ed4795875d09bb5c0bbe504f06dd5 # v1.14.40
+      uses: anomalyco/opencode/github@8ba2a9171597262df9d19516c82a5e14f18f5c63 # v1.14.41
       timeout-minutes: ${{ inputs.timeout-minutes }}
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
 
           # Check if there are changes to commit
           if [ -n "$(git status --porcelain)" ]; then
+            bunx oxfmt CHANGELOG.md package.json
             git add CHANGELOG.md package.json
             git commit -m "chore: release v${{ steps.bump.outputs.new_version }}"
             git push origin "$BRANCH_NAME"

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/setup-environment
 
       - name: Run Fallow analysis
-        uses: fallow-rs/fallow@4e148af6934d4c077fde98a8e7708d4dfbbb2540 # v2.66.2
+        uses: fallow-rs/fallow@36a5ab1e4475a92727d21568419cb9e89c2f3484 # v2.67.0
         with:
           format: sarif
           comment: true
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: fallow-results.sarif
           category: fallow-analysis-${{ github.run_id }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run Issue Triage
         if: steps.check.outputs.result == 'true'
-        uses: anomalyco/opencode/github@277f1c71486ed4795875d09bb5c0bbe504f06dd5 # v1.14.40
+        uses: anomalyco/opencode/github@8ba2a9171597262df9d19516c82a5e14f18f5c63 # v1.14.41
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: ./.github/actions/disable-submodules
 
       - name: Run Code Review
-        uses: anomalyco/opencode/github@277f1c71486ed4795875d09bb5c0bbe504f06dd5 # v1.14.40
+        uses: anomalyco/opencode/github@8ba2a9171597262df9d19516c82a5e14f18f5c63 # v1.14.41
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@ title: Changelog
 description: All notable changes to this project
 ---
 
-## v0.0.2
-
+## v0.0.0
 
 ### 🚀 Enhancements
 
@@ -21,6 +20,11 @@ description: All notable changes to this project
 - Add versioning workflow with PR pre-release support ([#69](https://github.com/rjoydip/tsse-elysia/pull/69))
 - Add versioning workflow with PR pre-release support ([f8f291b](https://github.com/rjoydip/tsse-elysia/commit/f8f291b))
 - Add users management with dashboard and API ([#72](https://github.com/rjoydip/tsse-elysia/pull/72))
+- Implement API layered architecture (HTTP → Controller → Service → Repository) ([#61](https://github.com/rjoydip/tsse-elysia/pull/61))
+- Add Fallow health badge with CI automation
+- Add /api/meta endpoint and display version in footer
+- Add fallow configuration and update development workflow
+- Add commitizen for guided conventional commits
 
 ### 🩹 Fixes
 
@@ -33,6 +37,11 @@ description: All notable changes to this project
 - Automate CHANGELOG and version bump on PR merge to main ([#73](https://github.com/rjoydip/tsse-elysia/pull/73))
 - Remove pull_request.merged condition for release tag creation ([#77](https://github.com/rjoydip/tsse-elysia/pull/77))
 - Remove --force-if-needed from tag push in CI workflow ([#78](https://github.com/rjoydip/tsse-elysia/pull/78))
+- Fix the workflow issue which introduced in previous PR ([#67](https://github.com/rjoydip/tsse-elysia/pull/67))
+- Add id prop to Input component for label association
+- Resolve circular dependencies, duplicate exports, and TypeScript errors
+- Resolve duplicate ChangelogEntry export between features and services
+- Resolve codeql/upload-sarif category conflict in fallow workflow
 
 ### 💅 Refactors
 
@@ -42,64 +51,31 @@ description: All notable changes to this project
 - Implement API layered architecture (HTTP → Controller → Service → Repository) ([#61](https://github.com/rjoydip/tsse-elysia/pull/61))
 - Introduce reusable GitHub Actions components ([#68](https://github.com/rjoydip/tsse-elysia/pull/68))
 - Add dependency injection to repositories and update docs to tanstack-form ([608e3e6](https://github.com/rjoydip/tsse-elysia/commit/608e3e6))
-
-### 📖 Documentation
-
-- Reorganize docs, add frontmatter support, fix E2E tests ([#6](https://github.com/rjoydip/tsse-elysia/pull/6))
-- Update commands.md with all package.json scripts and fix DECISIONS.md reference ([#64](https://github.com/rjoydip/tsse-elysia/pull/64))
-
-### 🏡 Chore
-
-- Release v0.1.0 [skip ci] ([aad40fa](https://github.com/rjoydip/tsse-elysia/commit/aad40fa))
-- Release v0.0.1 ([084b4c0](https://github.com/rjoydip/tsse-elysia/commit/084b4c0))
-
-### ✅ Tests
-
-- Add unit tests for PostgreSQL replica configuration ([#17](https://github.com/rjoydip/tsse-elysia/pull/17))
-
-### 🤖 CI
-
-- Ignored react doctor and commented out database migration ([#1](https://github.com/rjoydip/tsse-elysia/pull/1))
-- Fix the workflow issue which introduced in previous PR ([#67](https://github.com/rjoydip/tsse-elysia/pull/67))
-
-### ❤️ Contributors
-
-- Joydip Roy ([@rjoydip](https://github.com/rjoydip))
-
-## v0.0.0
-
-### 🚀 Enhancements
-
-- Implement Redis integration with rate limiting, authentication, and documentation infrastructure ([#13](https://github.com/rjoydip/tsse-elysia/pull/13))
-- Implement LLM Optimization (LLMO) features ([#22](https://github.com/rjoydip/tsse-elysia/pull/22))
-- Enhance status page with cache infrastructure and latency graph ([#24](https://github.com/rjoydip/tsse-elysia/pull/24))
-- Enhance GitHub Actions with decisions log enforcement and task syncing ([#25](https://github.com/rjoydip/tsse-elysia/pull/25))
-- Implement user profile details display ([#42](https://github.com/rjoydip/tsse-elysia/pull/42))
-- Implement API layered architecture (HTTP → Controller → Service → Repository) ([#61](https://github.com/rjoydip/tsse-elysia/pull/61))
-- Add Fallow health badge with CI automation
-- Add /api/meta endpoint and display version in footer
-- Add fallow configuration and update development workflow
-- Add commitizen for guided conventional commits
-
-### 💅 Refactors
-
-- Update logger to use Consola and add commands documentation ([#20](https://github.com/rjoydip/tsse-elysia/pull/20))
-- Resolve auth store hook issues and update dependencies ([#19](https://github.com/rjoydip/tsse-elysia/pull/19))
-- Implement reusable GitHub Actions components ([#68](https://github.com/rjoydip/tsse-elysia/pull/68))
 - Extract shared components and utilities to reduce code duplication
 - Split monolithic schema into modular files
 - Reorganize lib directory structure
 - Move business logic to services layer
 
-### 🩹 Fixes
+### 📖 Documentation
 
-- Resolve SSR hydration errors and update auth store tests ([#26](https://github.com/rjoydip/tsse-elysia/pull/26))
-- Prevent duplicate issue creation in sync-tasks workflow ([#60](https://github.com/rjoydip/tsse-elysia/pull/60))
-- Fix the workflow issue which introduced in previous PR ([#67](https://github.com/rjoydip/tsse-elysia/pull/67))
-- Add id prop to Input component for label association
-- Resolve circular dependencies, duplicate exports, and TypeScript errors
-- Resolve duplicate ChangelogEntry export between features and services
-- Resolve codeql/upload-sarif category conflict in fallow workflow
+- Reorganize docs, add frontmatter support, fix E2E tests ([#6](https://github.com/rjoydip/tsse-elysia/pull/6))
+- Update commands.md with all package.json scripts and fix DECISIONS.md reference ([#64](https://github.com/rjoydip/tsse-elysia/pull/64))
+- Add commands.md with all package.json scripts
+- Add CODECOV_TOKEN to CI/CD secrets documentation
+- Add Fallow MCP integration knowledge document
+- Add DECISION 017 and 018 for GitHub Actions workflow changes
+- Update folder structure and tech stack in documentation
+
+### 🏡 Chore
+
+- Release v0.1.0 [skip ci] ([aad40fa](https://github.com/rjoydip/tsse-elysia/commit/aad40fa))
+- Release v0.0.1 ([084b4c0](https://github.com/rjoydip/tsse-elysia/commit/084b4c0))
+- Add commitizen and standard-version for conventional commits
+- Add versioning workflow with PR pre-release support
+
+### ✅ Tests
+
+- Add unit tests for PostgreSQL replica configuration ([#17](https://github.com/rjoydip/tsse-elysia/pull/17))
 
 ### 🏗️ Infrastructure
 
@@ -108,27 +84,16 @@ description: All notable changes to this project
 - Add Docker build with multi-stage builds for production
 - Add E2E test infrastructure with dynamic database adapter
 
-### 📖 Documentation
-
-- Add commands.md with all package.json scripts
-- Add CODECOV_TOKEN to CI/CD secrets documentation
-- Add Fallow MCP integration knowledge document
-- Add DECISION 017 and 018 for GitHub Actions workflow changes
-- Update folder structure and tech stack in documentation
-
 ### 🤖 CI
 
+- Ignored react doctor and commented out database migration ([#1](https://github.com/rjoydip/tsse-elysia/pull/1))
+- Fix the workflow issue which introduced in previous PR ([#67](https://github.com/rjoydip/tsse-elysia/pull/67))
 - Add fallow analysis workflow for GitHub Actions
 - Add decisions-check.yml for architecture enforcement
 - Add sync-tasks.yml for task-to-issue automation
 - Add pr-review.yml for automated PR reviews
 - Add issue-triage.yml for automated issue triage
 - Add docker-scan job for container security
-
-### 🏡 Chore
-
-- Add commitizen and standard-version for conventional commits
-- Add versioning workflow with PR pre-release support
 
 ### ❤️ Contributors
 

--- a/knowledge/DECISIONS.md
+++ b/knowledge/DECISIONS.md
@@ -1000,6 +1000,35 @@ git push origin v1.2.3
 
 ---
 
+### 026: Format CHANGELOG and package.json Before Release Commit
+
+**Status:** Accepted
+
+**Why:**
+
+- Ensure consistent formatting of CHANGELOG.md and package.json before committing version changes
+- Prevent unformatted files from being committed during automated release process
+- Align with project's code style standards
+
+**Changes:**
+
+Added `bunx oxfmt CHANGELOG.md package.json` step in `ci.yml` release workflow before git commit:
+
+```yaml
+if [ -n "$(git status --porcelain)" ]; then
+  bunx oxfmt CHANGELOG.md package.json
+  git add CHANGELOG.md package.json
+  git commit -m "chore: release v${{ steps.bump.outputs.new_version }}"
+  ...
+```
+
+**Tradeoffs:**
+
+- ⚠️ Additional step adds small delay to release process (~1-2 seconds)
+- ✅ Ensures consistent formatting across all releases
+
+---
+
 ## Rules
 
 - Every major decision MUST be logged

--- a/src/features/chats/index.tsx
+++ b/src/features/chats/index.tsx
@@ -56,7 +56,7 @@ export function Chats() {
   }, {});
 
   // oxlint-disable-next-line: no-unused-vars
-  const users = conversations.map(({ messages, ...user }) => user);
+  const users = conversations.map(({ _, ...user }) => user);
 
   return (
     <>

--- a/src/features/chats/index.tsx
+++ b/src/features/chats/index.tsx
@@ -55,8 +55,7 @@ export function Chats() {
     return acc;
   }, {});
 
-  // oxlint-disable-next-line: no-unused-vars
-  const users = conversations.map(({ _, ...user }) => user);
+  const users = conversations.map(({ messages: _messages, ...user }) => user);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Runs \unx oxfmt CHANGELOG.md package.json\ before committing version changes in the release workflow to ensure proper formatting