### PR TITLE
feat: add nightly dev build workflow

### DIFF
--- a/.github/actions/compute-nightly-version/action.yml
+++ b/.github/actions/compute-nightly-version/action.yml
@@ -1,0 +1,22 @@
+name: Compute Nightly Version
+description: Compute nightly version string (0.0.0-dev.YYYYMMDD.<sha>) and date
+
+outputs:
+  version:
+    description: Nightly version string
+    value: ${{ steps.compute.outputs.version }}
+  date:
+    description: Date in YYYYMMDD format
+    value: ${{ steps.compute.outputs.date }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute nightly version
+      id: compute
+      shell: bash
+      run: |
+        DATE=$(date +%Y%m%d)
+        SHA=$(git rev-parse --short HEAD)
+        echo "version=0.0.0-dev.${DATE}.${SHA}" >> "$GITHUB_OUTPUT"
+        echo "date=${DATE}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/run-opencode/action.yml
+++ b/.github/actions/run-opencode/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Run OpenCode AI
-      uses: anomalyco/opencode/github@58a27b95c155d3f7d9b9f25b30eb1233bfb0eae5 # v1.15.12
+      uses: anomalyco/opencode/github@385cb694419f98103af0e8fc6187ddcbcbb6eecb # v1.15.13
       timeout-minutes: ${{ inputs.timeout-minutes }}
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/setup-environment
 
       - name: Run Fallow analysis
-        uses: fallow-rs/fallow@1fe7ae6722408aa817501c164933637a57af56a9 # v2.84.0
+        uses: fallow-rs/fallow@71cefac7af05f17732482241c7671a401707cc9d # v2.85.0
         with:
           format: sarif
           comment: true

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run Issue Triage
         if: steps.check.outputs.result == 'true'
-        uses: anomalyco/opencode/github@58a27b95c155d3f7d9b9f25b30eb1233bfb0eae5 # v1.15.12
+        uses: anomalyco/opencode/github@385cb694419f98103af0e8fc6187ddcbcbb6eecb # v1.15.13
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
         run: bun test:coverage --run
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16 # v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
@@ -98,13 +98,10 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
 
-      - id: version
-        uses: ./.github/actions/compute-nightly-version
-
       - name: Download build artifact
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: tsse-elysia-nightly-${{ steps.version.outputs.version }}
+          name: tsse-elysia-nightly-${{ needs.build.outputs.version }}
           path: dist/
 
       - name: Resolve host IP
@@ -150,19 +147,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - id: version
-        uses: ./.github/actions/compute-nightly-version
-
       - name: Download build artifact
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: tsse-elysia-nightly-${{ steps.version.outputs.version }}
+          name: tsse-elysia-nightly-${{ needs.build.outputs.version }}
           path: dist/
 
       - name: Create nightly archive
         run: |
-          tar -czf tsse-elysia-nightly-${{ steps.version.outputs.version }}.tar.gz dist/
-          zip -r tsse-elysia-nightly-${{ steps.version.outputs.version }}.zip dist/
+          tar -czf tsse-elysia-nightly-${{ needs.build.outputs.version }}.tar.gz dist/
+          zip -r tsse-elysia-nightly-${{ needs.build.outputs.version }}.zip dist/
 
       - name: Delete existing nightly release (if any)
         env:
@@ -181,10 +175,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "nightly" \
-            --title "Nightly Dev Build — ${{ steps.version.outputs.date }}" \
+            --title "Nightly Dev Build — ${{ needs.build.outputs.date }}" \
             --notes "## Nightly Dev Build
 
-          **Version:** ${{ steps.version.outputs.version }}
+          **Version:** ${{ needs.build.outputs.version }}
           **Date:** $(date -u '+%Y-%m-%d %H:%M UTC')
           **Commit:** ${{ github.sha }}
 
@@ -203,10 +197,10 @@ jobs:
 
           ${{ github.event.head_commit.message || 'Latest commits from main branch.' }}" \
             --prerelease \
-            tsse-elysia-nightly-${{ steps.version.outputs.version }}.tar.gz \
-            tsse-elysia-nightly-${{ steps.version.outputs.version }}.zip
+            tsse-elysia-nightly-${{ needs.build.outputs.version }}.tar.gz \
+            tsse-elysia-nightly-${{ needs.build.outputs.version }}.zip
 
-      - name: Prune old nightly artifacts
+      - name: Prune old workflow runs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
         run: bun test:coverage --run
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@0565863a31f2c772f9fbb5005f860dcbb7c08879 # v6.0.1
+        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,216 @@
+name: Nightly Dev Build
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DATABASE_TYPE: "sqlite"
+  SQLITE_URL: "file:.artifacts/tsse-elysia.db"
+
+jobs:
+  quality:
+    name: Quality Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - uses: ./.github/actions/run-quality-checks
+
+  test:
+    name: Unit Tests & Coverage
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - uses: ./.github/actions/setup-database
+        with:
+          operation: setup
+
+      - name: Run tests with coverage
+        run: bun test:coverage --run
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0565863a31f2c772f9fbb5005f860dcbb7c08879 # v6.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: nightly
+          name: nightly-coverage
+          fail_ci_if_error: false
+
+      - uses: ./.github/actions/setup-database
+        with:
+          operation: remove
+        if: always()
+
+  build:
+    name: Build & Artifact
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Compute nightly version
+        id: version
+        run: |
+          DATE=$(date +%Y%m%d)
+          SHA=$(git rev-parse --short HEAD)
+          echo "version=0.0.0-dev.${DATE}.${SHA}" >> $GITHUB_OUTPUT
+          echo "date=${DATE}" >> $GITHUB_OUTPUT
+
+      - name: Build application
+        run: bun run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tsse-elysia-nightly-${{ steps.version.outputs.version }}
+          path: dist/
+          retention-days: 30
+
+  e2e:
+    name: E2E Tests
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-environment
+
+      - uses: ./.github/actions/setup-database
+        with:
+          operation: setup
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build
+        run: bun run build
+
+      - name: Resolve host IP
+        run: |
+          HOST_IP=$(ip route get 1.1.1.1 | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')
+          echo "E2E_HOST=$HOST_IP" >> $GITHUB_ENV
+          echo "E2E_BASE_URL=http://$HOST_IP:4173" >> $GITHUB_ENV
+          echo "BETTER_AUTH_URL=http://$HOST_IP:4173/api/auth" >> $GITHUB_ENV
+
+      - name: Start preview server
+        env:
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+        run: |
+          bun run preview --port 4173 --host $E2E_HOST &
+          for i in $(seq 1 30); do
+            if curl -sf http://$E2E_HOST:4173 > /dev/null 2>&1; then
+              echo "Server ready"
+              break
+            fi
+            sleep 2
+          done
+
+      - name: Run E2E tests
+        run: bun test:e2e
+
+      - name: Stop preview server
+        if: always()
+        run: pkill -f "bun run preview" || true
+
+      - uses: ./.github/actions/setup-database
+        with:
+          operation: remove
+        if: always()
+
+  release:
+    name: Create Nightly Release
+    needs: [build, test, e2e]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Compute nightly version
+        id: version
+        run: |
+          DATE=$(date +%Y%m%d)
+          SHA=$(git rev-parse --short HEAD)
+          echo "version=0.0.0-dev.${DATE}.${SHA}" >> $GITHUB_OUTPUT
+          echo "date=${DATE}" >> $GITHUB_OUTPUT
+
+      - name: Download build artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: tsse-elysia-nightly-${{ steps.version.outputs.version }}
+          path: dist/
+
+      - name: Create nightly archive
+        run: |
+          tar -czf tsse-elysia-nightly-${{ steps.version.outputs.version }}.tar.gz dist/
+          zip -r tsse-elysia-nightly-${{ steps.version.outputs.version }}.zip dist/
+
+      - name: Delete existing nightly release (if any)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete "nightly" --yes --repo ${{ github.repository }} 2>/dev/null || true
+
+      - name: Delete existing nightly tag (if any)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin --delete refs/tags/nightly 2>/dev/null || true
+
+      - name: Create nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "nightly" \
+            --title "Nightly Dev Build — ${{ steps.version.outputs.date }}" \
+            --notes "## Nightly Dev Build
+
+          **Version:** ${{ steps.version.outputs.version }}
+          **Date:** $(date -u '+%Y-%m-%d %H:%M UTC')
+          **Commit:** ${{ github.sha }}
+
+          ### ⚠️ Not for production use
+
+          This is a nightly development build with the latest changes.
+          It may contain unstable features, unfinished work, or bugs.
+
+          ### Artifacts
+
+          - \`dist/\` — Full production build output
+          - \`*.tar.gz\` — Tarball archive
+          - \`*.zip\` — ZIP archive
+
+          ### Changes included
+
+          ${{ github.event.head_commit.message || 'Latest commits from main branch.' }}" \
+            --prerelease \
+            tsse-elysia-nightly-${{ steps.version.outputs.version }}.tar.gz \
+            tsse-elysia-nightly-${{ steps.version.outputs.version }}.zip
+
+      - name: Prune old nightly artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Keep only the latest 30 nightly artifacts
+          gh run list --workflow nightly.yml --branch main --limit 60 --json databaseId \
+            --jq '.[].databaseId' | tail -n +31 | while read id; do
+            gh run delete "$id" --repo ${{ github.repository }} --yes 2>/dev/null || true
+          done

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,19 +60,17 @@ jobs:
     name: Build & Artifact
     needs: quality
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      date: ${{ steps.version.outputs.date }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Compute nightly version
-        id: version
-        run: |
-          DATE=$(date +%Y%m%d)
-          SHA=$(git rev-parse --short HEAD)
-          echo "version=0.0.0-dev.${DATE}.${SHA}" >> $GITHUB_OUTPUT
-          echo "date=${DATE}" >> $GITHUB_OUTPUT
+      - id: version
+        uses: ./.github/actions/compute-nightly-version
 
       - name: Build application
         run: bun run build
@@ -86,7 +84,7 @@ jobs:
 
   e2e:
     name: E2E Tests
-    needs: quality
+    needs: [quality, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -100,12 +98,18 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
 
-      - name: Build
-        run: bun run build
+      - id: version
+        uses: ./.github/actions/compute-nightly-version
+
+      - name: Download build artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: tsse-elysia-nightly-${{ steps.version.outputs.version }}
+          path: dist/
 
       - name: Resolve host IP
         run: |
-          HOST_IP=$(ip route get 1.1.1.1 | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')
+          HOST_IP=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}') || HOST_IP="127.0.0.1"
           echo "E2E_HOST=$HOST_IP" >> $GITHUB_ENV
           echo "E2E_BASE_URL=http://$HOST_IP:4173" >> $GITHUB_ENV
           echo "BETTER_AUTH_URL=http://$HOST_IP:4173/api/auth" >> $GITHUB_ENV
@@ -115,6 +119,8 @@ jobs:
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
         run: |
           bun run preview --port 4173 --host $E2E_HOST &
+          SERVER_PID=$!
+          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
           for i in $(seq 1 30); do
             if curl -sf http://$E2E_HOST:4173 > /dev/null 2>&1; then
               echo "Server ready"
@@ -128,7 +134,7 @@ jobs:
 
       - name: Stop preview server
         if: always()
-        run: pkill -f "bun run preview" || true
+        run: kill $SERVER_PID 2>/dev/null || true
 
       - uses: ./.github/actions/setup-database
         with:
@@ -144,13 +150,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Compute nightly version
-        id: version
-        run: |
-          DATE=$(date +%Y%m%d)
-          SHA=$(git rev-parse --short HEAD)
-          echo "version=0.0.0-dev.${DATE}.${SHA}" >> $GITHUB_OUTPUT
-          echo "date=${DATE}" >> $GITHUB_OUTPUT
+      - id: version
+        uses: ./.github/actions/compute-nightly-version
 
       - name: Download build artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: ./.github/actions/disable-submodules
 
       - name: Run Code Review
-        uses: anomalyco/opencode/github@58a27b95c155d3f7d9b9f25b30eb1233bfb0eae5 # v1.15.12
+        uses: anomalyco/opencode/github@385cb694419f98103af0e8fc6187ddcbcbb6eecb # v1.15.13
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/docs/infra/ci-cd.md
+++ b/docs/infra/ci-cd.md
@@ -188,11 +188,14 @@ Dev builds are automatically created daily at midnight UTC via `.github/workflow
 
 **Required secrets:**
 
-| Secret               | Purpose                                   |
-| -------------------- | ----------------------------------------- |
-| `GH_TOKEN`           | Creating/updating nightly release         |
-| `BETTER_AUTH_SECRET` | Preview server for E2E tests              |
-| `CODECOV_TOKEN`      | Coverage upload (optional, non-blocking)  |
+| Secret               | Purpose                                            |
+| -------------------- | -------------------------------------------------- |
+| `GITHUB_TOKEN`       | Built-in token (auto-set, needs `contents: write`) |
+| `BETTER_AUTH_SECRET` | Preview server for E2E tests                       |
+| `CODECOV_TOKEN`      | Coverage upload (optional, non-blocking)           |
+
+> Nightly workflows use `secrets.GITHUB_TOKEN` (aliased via `env: GH_TOKEN` for `gh` CLI compatibility).
+> No separate user-managed `GH_TOKEN` secret is needed — the built-in token provides `contents: write`.
 
 ## Manual Release
 

--- a/docs/infra/ci-cd.md
+++ b/docs/infra/ci-cd.md
@@ -151,11 +151,48 @@ Tags follow [SemVer](https://semver.org/) format: `vMAJOR.MINOR.PATCH`
 
 ### Nightly Builds
 
-Dev builds are automatically created daily at midnight UTC:
+Dev builds are automatically created daily at midnight UTC via `.github/workflows/nightly.yml`.
 
-- Version: `0.0.0-dev.YYYYMMDD.commitCount`
-- Download from "Nightly Dev" GitHub Release
+**Schedule:** `cron: 0 0 * * *` (daily) + manual trigger via `workflow_dispatch`
+
+**Workflow:**
+
+```text
+[Schedule Trigger] → Quality Checks → Unit Tests ─┐
+                                        ├─ Build & Artifact ─┐
+                                        └─ E2E Tests ────────┤
+                                                            ↓
+                                              Create Nightly Release
+```
+
+**Jobs:**
+
+| Job       | Description                                      |
+| --------- | ------------------------------------------------ |
+| `quality` | Lint and typecheck (reuses `run-quality-checks`) |
+| `test`    | Unit tests with coverage, uploaded to Codecov    |
+| `build`   | Production build, uploaded as artifact (30 days) |
+| `e2e`     | End-to-end tests with Playwright                 |
+| `release` | Creates "Nightly" GitHub Release with artifacts  |
+
+**Version scheme:** `0.0.0-dev.YYYYMMDD.<short-sha>` — unique per day, no semver bump.
+
+**Artifacts:**
+- Full `dist/` build output
+- `.tar.gz` and `.zip` archives
+
+**Release management:**
+- Single "Nightly" GitHub Release (prerelease), overwritten daily
+- Old workflow runs pruned after 30 entries
 - **Not for production use**
+
+**Required secrets:**
+
+| Secret               | Purpose                                   |
+| -------------------- | ----------------------------------------- |
+| `GH_TOKEN`           | Creating/updating nightly release         |
+| `BETTER_AUTH_SECRET` | Preview server for E2E tests              |
+| `CODECOV_TOKEN`      | Coverage upload (optional, non-blocking)  |
 
 ## Manual Release
 

--- a/knowledge/DECISIONS.md
+++ b/knowledge/DECISIONS.md
@@ -1408,6 +1408,44 @@ Created multi-stage Dockerfile with 4 stages:
 
 ---
 
+### 040: Nightly Dev Build Workflow
+
+**Status:** Accepted
+
+**Date:** 2026-06-01
+
+**Why:**
+
+- Provide daily development builds for testing and validation
+- Catch regressions early with full test suite + E2E runs on a schedule
+- Make latest changes available as pre-built artifacts without requiring a formal release
+- Establish a consistent nightly cadence independent of PR merges
+
+**Approach:**
+
+- GitHub Actions scheduled workflow at midnight UTC (cron: `0 0 * * *`)
+- Runs full quality checks (lint, typecheck), unit tests with coverage, E2E tests, and production build
+- Creates a "Nightly" GitHub Release (prerelease) with build artifacts (tarball + zip)
+- Version scheme: `0.0.0-dev.<YYYYMMDD>.<short-sha>` — unique per day, no semver bumps
+- Retains last 30 run artifacts; older ones pruned automatically
+- Also triggerable manually via `workflow_dispatch`
+
+**Alternatives Considered:**
+
+- Separate cron job on a dedicated server — more maintenance overhead than GitHub-hosted runner
+- Docker-based nightly image push to registry — adds complexity; not needed until container registries are in use
+- Publish to npm as `dev` tag — overkill; app is not a library
+
+**Tradeoffs:**
+
+- ⚠️ Nightly release tag is overwritten each day (single "nightly" tag, not versioned)
+- ⚠️ Requires `GH_TOKEN` with `contents: write` permission for release creation
+- ✅ Full CI pipeline runs daily, catching issues faster
+- ✅ Artifacts available for 30 days; no manual cleanup
+- ✅ No impact on PR CI or release workflow (separate concurrency group)
+
+---
+
 ## Rules
 
 - Every major decision MUST be logged

--- a/knowledge/DECISIONS.md
+++ b/knowledge/DECISIONS.md
@@ -1439,7 +1439,7 @@ Created multi-stage Dockerfile with 4 stages:
 **Tradeoffs:**
 
 - ⚠️ Nightly release tag is overwritten each day (single "nightly" tag, not versioned)
-- ⚠️ Requires `GH_TOKEN` with `contents: write` permission for release creation
+- ⚠️ Uses built-in `secrets.GITHUB_TOKEN` (aliased via `env: GH_TOKEN` for `gh` CLI) — no user-managed PAT needed, but requires `contents: write` permission on the token
 - ✅ Full CI pipeline runs daily, catching issues faster
 - ✅ Artifacts available for 30 days; no manual cleanup
 - ✅ No impact on PR CI or release workflow (separate concurrency group)

--- a/knowledge/PLANS.md
+++ b/knowledge/PLANS.md
@@ -64,8 +64,30 @@ Core focus:
 | 17    | Dashboard UI Polish                 | ✅     |
 | 18    | Dashboard Stability & HMR Fixes     | ✅     |
 | 19    | Production Seed & Env-Aware Seeding | ✅     |
+| 20    | Nightly Dev Build Workflow          | ✅     |
 
 ---
+
+## Completed Phases
+
+### Phase 20 – Nightly Dev Build Workflow ✅
+
+**Completed:**
+
+- Created `.github/workflows/nightly.yml` with scheduled `cron: 0 0 * * *` + manual trigger
+- Runs quality checks, unit tests (coverage), E2E tests, and production build
+- Creates/updates a "Nightly" GitHub Release (prerelease) with build artifacts
+- Version scheme: `0.0.0-dev.YYYYMMDD.<short-sha>` (unique daily, no semver bump)
+- Automatically prunes old workflow runs (keeps last 30)
+- Decision doc: `DECISIONS.md:decision-040-nightly-dev-build-workflow`
+- CI/CD docs updated in `docs/infra/ci-cd.md` with full workflow details
+
+**Benefits:**
+
+- Daily regression detection via full test suite
+- Pre-built artifacts available without formal releases
+- Consistent cadence independent of PR merges
+- Manual trigger available for ad-hoc dev builds
 
 ## Active Focus
 
@@ -277,6 +299,7 @@ src/
 - [Phase 11: Database Refactoring](./plans/phase-11-db0-database-refactoring.md)
 - [Phase 13: Contract Testing](./plans/phase-13-contract-testing-implementation-plan.md)
 - [Phase 15: Replace Fake Dashboard Analytics with Real User Data](./plans/phase-15-dashboard-real-user-data.md)
+- [Phase 20: Nightly Dev Build Workflow](./.github/workflows/nightly.yml)
 
 ---
 

--- a/knowledge/PLANS.md
+++ b/knowledge/PLANS.md
@@ -64,13 +64,13 @@ Core focus:
 | 17    | Dashboard UI Polish                 | ✅     |
 | 18    | Dashboard Stability & HMR Fixes     | ✅     |
 | 19    | Production Seed & Env-Aware Seeding | ✅     |
-| 20    | Nightly Dev Build Workflow          | ✅     |
+| 21    | Nightly Dev Build Workflow          | ✅     |
 
 ---
 
 ## Completed Phases
 
-### Phase 20 – Nightly Dev Build Workflow ✅
+### Phase 21 – Nightly Dev Build Workflow ✅
 
 **Completed:**
 
@@ -299,7 +299,7 @@ src/
 - [Phase 11: Database Refactoring](./plans/phase-11-db0-database-refactoring.md)
 - [Phase 13: Contract Testing](./plans/phase-13-contract-testing-implementation-plan.md)
 - [Phase 15: Replace Fake Dashboard Analytics with Real User Data](./plans/phase-15-dashboard-real-user-data.md)
-- [Phase 20: Nightly Dev Build Workflow](./.github/workflows/nightly.yml)
+- [Phase 21: Nightly Dev Build Workflow](./.github/workflows/nightly.yml)
 
 ---
 

--- a/knowledge/PLANS.md
+++ b/knowledge/PLANS.md
@@ -64,6 +64,7 @@ Core focus:
 | 17    | Dashboard UI Polish                 | ✅     |
 | 18    | Dashboard Stability & HMR Fixes     | ✅     |
 | 19    | Production Seed & Env-Aware Seeding | ✅     |
+| 20    | Dashboard Code Review Fixes         | ✅     |
 | 21    | Nightly Dev Build Workflow          | ✅     |
 
 ---


### PR DESCRIPTION
- **New workflow**: `.github/workflows/nightly.yml` — scheduled daily at midnight UTC + manual trigger
- **Jobs**: quality checks, unit tests (coverage), production build, E2E tests, nightly release
- **Version scheme**: `0.0.0-dev.YYYYMMDD.<short-sha>` — unique daily, no semver bump
- **Release**: Single Nightly GitHub Release (prerelease), overwritten daily, artifacts retained 30 days
- **Decision #040**: Nightly Dev Build Workflow — rationale and tradeoffs documented
- **PLANS.md**: Phase 20 marked complete
- **CI/CD docs**: Updated with full nightly build details